### PR TITLE
Implement `__iter__` for convenient conversion to `dict`

### DIFF
--- a/sensirion_i2c_sen5x/measured_values.py
+++ b/sensirion_i2c_sen5x/measured_values.py
@@ -123,3 +123,20 @@ class Sen5xMeasuredValues:
             str
         """
         return self.to_str()
+
+    def __iter__(self):
+        keys_vals = dict(
+            mc_1p0 = self.mass_concentration_1p0.physical,
+            mc_2p5 = self.mass_concentration_2p5.physical,
+            mc_4p0 = self.mass_concentration_4p0.physical,
+            mc_10p0 = self.mass_concentration_10p0.physical,
+            ambient_rh = self.ambient_humidity.percent_rh,
+            ambient_t = self.ambient_temperature.degrees_celsius,
+            voc_index = self.voc_index.scaled,
+            nox_index = self.nox_index.scaled,
+        )
+        for key, item in keys_vals.items():
+            yield key, item
+
+
+


### PR DESCRIPTION
Now it is possible to convert into a `dict`:

```python
from time import sleep
from sensirion_i2c_driver import I2cConnection, LinuxI2cTransceiver
from sensirion_i2c_sen5x import Sen5xI2cDevice

with LinuxI2cTransceiver('/dev/i2c-1') as i2c_transceiver:
	device = Sen5xI2cDevice(I2cConnection(i2c_transceiver))
	device.device_reset()
	device.start_measurement()
	sleep(2)
	while device.read_data_ready() is False:
		sleep(0.1)
	result = device.read_measured_values()
	result = dict(result)
	print(result)
```
```
$ python main.py 
{'mc_1p0': 3.6, 'mc_2p5': 6.4, 'mc_4p0': 8.6, 'mc_10p0': 9.6, 'ambient_rh': 45.66, 'ambient_t': 30.105, 'voc_index': 0.0, 'nox_index': nan}
```